### PR TITLE
Mark the shared->sync conversion as unsafe

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -18,6 +18,14 @@ impl<T> SyncPointer<T> {
     pub fn new(data: T) -> SyncPointer<T> {
         SyncPointer::from(Arc::new(data))
     }
+
+    pub unsafe fn from_shared(ptr: SharedPointer<T>) -> SyncPointer<T> {
+        // ... or use TryFrom? (currently nightly)
+        if !ptr.inner.sync {
+            panic!("Cannot upgrade non-threadsafe SharedPointer to SyncPointer");
+        }
+        SyncPointer { inner: ptr.inner }
+    }
 }
 
 impl<T: ?Sized> Deref for SyncPointer<T> {
@@ -35,15 +43,6 @@ impl<T: ?Sized> From<&'static T> for SyncPointer<T> {
 impl<T: ?Sized> From<Arc<T>> for SyncPointer<T> {
     fn from(ptr: Arc<T>) -> SyncPointer<T> {
         SyncPointer { inner: Pointer::from(ptr) }
-    }
-}
-
-impl<T: ?Sized> From<SharedPointer<T>> for SyncPointer<T> {
-    fn from(ptr: SharedPointer<T>) -> SyncPointer<T> {
-        if !ptr.inner.sync {
-            panic!("Cannot upgrade non-threadsafe SharedPointer to SyncPointer");
-        }
-        SyncPointer { inner: ptr.inner }
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -36,16 +36,21 @@ fn construct_sync_from_arc() {
 
 #[test]
 fn convert_from_static() {
-    assert_eq!(*SyncPointer::from(SharedPointer::from(&X)), 0);
+    let shared_ptr = SharedPointer::from(&X);
+    let sync_ptr = unsafe { SyncPointer::from_shared(shared_ptr) };
+    assert_eq!(*sync_ptr, 0);
 }
 
 #[test]
 #[should_panic]
 fn convert_from_rc_panics() {
-    SyncPointer::from(SharedPointer::from(Rc::new(0)));
+    let shared_ptr = SharedPointer::from(Rc::new(0));
+    unsafe { SyncPointer::from_shared(shared_ptr) };
 }
 
 #[test]
 fn convert_from_arc() {
-    assert_eq!(*SyncPointer::from(SharedPointer::from(Arc::new(0))), 0);
+    let shared_ptr = SharedPointer::from(Arc::new(0));
+    let sync_ptr = unsafe { SyncPointer::from_shared(shared_ptr) };
+    assert_eq!(*sync_ptr, 0);
 }


### PR DESCRIPTION
I wondered if there was a way to model away from the hidden panic.

This is just an idea - does using 'unsafe' make sense in this scenario?  Interested in your thoughts.